### PR TITLE
feat: custom env inventory paths

### DIFF
--- a/.cursor/rules/00-main.mdc
+++ b/.cursor/rules/00-main.mdc
@@ -32,6 +32,6 @@ The goal is for all the code in this repository to appear as if it were written 
 
 This can include everything from naming files, classes, variables, or array keys to the precedence and type of parameters passed to a function, to how logic flows and how the code is organized or commented.
 
-**✔️ Don't worry about tests:** Write or run tests ONLY if specifically instructed
+**✔️ Tests are off-limits:** Don't run or edit tests; run or edit tests ONLY if explicitly instructed to do so!
 
 **🧠 AI Agent Protocol:** ULTRATHINK → STEP BY STEP → ACT

--- a/.cursor/rules/01-architecture.mdc
+++ b/.cursor/rules/01-architecture.mdc
@@ -1,6 +1,5 @@
 ---
-globs: app/**/*.php,tests/**/*.php
-alwaysApply: false
+alwaysApply: true
 ---
 
 ## Architecture Rules
@@ -83,9 +82,17 @@ $service = $container->build(TestService::class);
 
 - Services provide atomic, reusable functionality with no console I/O
 - Services accept plain PHP data types and return plain PHP data types
-- Services must be stateless and dependency-injected
+- Services must be dependency-injected via constructor
 - Services handle core business logic, external API calls, file operations
 - Complex orchestration shared by multiple Commands should be extracted to dedicated Services
+
+**Service State:**
+
+- **Stateless Services:** Pure operations with no internal state (e.g., validators, calculators, API clients)
+- **Stateful Services:** Services that manage configuration or cached data (e.g., config loaders, file managers, repositories)
+- Stateful services should use lazy loading when initialization is expensive or path-dependent
+- State must be initialized explicitly via public methods before use (e.g., `load()`, `initialize()`)
+- Services should document their stateful nature and initialization requirements
 
 ### Console I/O Rules
 

--- a/.cursor/rules/02-tests.mdc
+++ b/.cursor/rules/02-tests.mdc
@@ -1,5 +1,5 @@
 ---
-globs: app/**/*.php,tests/**/*.php
+alwaysApply: true
 ---
 
 ## Testing Rules

--- a/.cursor/rules/03-commands.mdc
+++ b/.cursor/rules/03-commands.mdc
@@ -1,6 +1,5 @@
 ---
-globs: app/Console/*.php,app/Contracts/BaseCommand.php,app/SymfonyApp.php
-description: Symfony Console rules
+alwaysApply: true
 ---
 
 ## Symfony Console Rules

--- a/.gitignore
+++ b/.gitignore
@@ -4,9 +4,10 @@
 .vscode/
 node_modules/
 vendor/
-*.cache
-*.log
 .DS_Store
 .env
 .env.*
+*.cache
+*.log
+inventory.yml
 Thumbs.db

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 ```
+ ╭──────────────────────────────────────────
   ┌┬┐┌─┐┌─┐┬  ┌─┐┬ ┬┌─┐┬─┐
    ││├┤ ├─┘│  │ │└┬┘├┤ ├┬┘
   ─┴┘└─┘┴  ┴─┘└─┘ ┴ └─┘┴└─PHP
 
-  The Server Provisioning & Deployment Tool for PHP
-
-  Support this project on GitHub ♥ https://github.com/bigpixelrocket/deployer-php
+  The Server & Site Deployment Tool for PHP
+ ╰──────────────────────────────────────────
 ```
 
 [![Tests](https://img.shields.io/badge/tests-passing-brightgreen.svg)](https://github.com/bigpixelrocket/deployer-php)

--- a/app/Console/HelloCommand.php
+++ b/app/Console/HelloCommand.php
@@ -18,6 +18,8 @@ class HelloCommand extends BaseCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        parent::execute($input, $output);
+
         $user = $this->env->get(['USER', 'USERNAME'], false) ?? 'there';
 
         $this->io->success('Hello ' . $user . '!');

--- a/app/Services/InventoryService.php
+++ b/app/Services/InventoryService.php
@@ -86,7 +86,7 @@ class InventoryService
     }
 
     /**
-     * Set a custom inventory path and reload.
+     * Set a custom inventory path.
      */
     public function setCustomPath(?string $path): void
     {

--- a/app/Services/InventoryService.php
+++ b/app/Services/InventoryService.php
@@ -34,17 +34,16 @@ use Symfony\Component\Yaml\Yaml;
  */
 class InventoryService
 {
-    private readonly string $inventoryPath;
-    private readonly string $inventoryDir;
+    /** @var array<string, mixed> */
+    private array $inventory = [];
 
-    private string $inventoryFileStatus = '';
+    private ?string $inventoryPath = null;
+
+    private ?string $inventoryFileStatus = null;
 
     public function __construct(
         private readonly Filesystem $filesystem,
     ) {
-        $this->inventoryPath = rtrim((string) getcwd(), '/').'/.deployer/inventory.yml';
-        $this->inventoryDir = dirname($this->inventoryPath);
-        $this->initializeInventoryFile();
     }
 
     //
@@ -56,43 +55,23 @@ class InventoryService
      */
     public function set(string $path, mixed $value): void
     {
-        $inventory = $this->readInventory();
         $segments = $this->parsePath($path);
 
-        $this->setByPath($inventory, $segments, $value);
-        $this->writeInventory($inventory);
+        $this->setByPath($this->inventory, $segments, $value);
+        $this->writeInventory();
     }
 
     /**
      * Get a value using dot notation path.
-     */
-    public function get(string $path): mixed
-    {
-        $inventory = $this->readInventory();
-        $segments = $this->parsePath($path);
-
-        return $this->getByPath($inventory, $segments);
-    }
-
-    /**
-     * Get the entire inventory structure.
      *
-     * @return array<string, mixed>
+     * @param mixed $default Default value to return if path doesn't exist
      */
-    public function getAll(): array
+    public function get(string $path, mixed $default = null): mixed
     {
-        return $this->readInventory();
-    }
-
-    /**
-     * Check if a path exists using dot notation.
-     */
-    public function has(string $path): bool
-    {
-        $inventory = $this->readInventory();
         $segments = $this->parsePath($path);
+        $value = $this->getByPath($this->inventory, $segments);
 
-        return $this->hasByPath($inventory, $segments);
+        return $value ?? $default;
     }
 
     /**
@@ -100,17 +79,43 @@ class InventoryService
      */
     public function delete(string $path): void
     {
-        $inventory = $this->readInventory();
         $segments = $this->parsePath($path);
 
-        $this->unsetByPath($inventory, $segments);
-        $this->writeInventory($inventory);
+        $this->unsetByPath($this->inventory, $segments);
+        $this->writeInventory();
+    }
+
+    /**
+     * Set a custom inventory path and reload.
+     */
+    public function setCustomPath(?string $path): void
+    {
+        $this->inventoryPath = $path;
+    }
+
+    /**
+     * Load and parse inventory file if it exists.
+     */
+    public function loadInventoryFile(): void
+    {
+        $this->inventory = [];
+
+        $path = $this->getInventoryPath();
+
+        // Initialize empty inventory file if it doesn't exist
+        if (!$this->filesystem->exists($path)) {
+            $this->inventoryFileStatus = "Creating inventory file at {$path}";
+            $this->writeInventory();
+        }
+
+        $this->readInventory();
+        $this->inventoryFileStatus = "Reading inventory from {$path}";
     }
 
     /**
      * Get the status of the inventory file.
      */
-    public function getInventoryFileStatus(): string
+    public function getInventoryFileStatus(): ?string
     {
         return $this->inventoryFileStatus;
     }
@@ -118,40 +123,6 @@ class InventoryService
     //
     // Private
     // -------------------------------------------------------------------------------
-
-    //
-    // Initialization
-
-    /**
-     * Initialize inventory file and set status.
-     */
-    private function initializeInventoryFile(): void
-    {
-        if (!$this->filesystem->exists($this->inventoryPath)) {
-            // Create empty inventory file
-            try {
-                if (!$this->filesystem->exists($this->inventoryDir)) {
-                    $this->filesystem->mkdir($this->inventoryDir, 0775);
-                }
-
-                $emptyYaml = Yaml::dump([], 2, 4, Yaml::DUMP_EMPTY_ARRAY_AS_SEQUENCE);
-                $this->filesystem->dumpFile($this->inventoryPath, $emptyYaml);
-                $this->inventoryFileStatus = "Creating inventory file at {$this->inventoryPath}";
-            } catch (\Throwable $e) {
-                $this->inventoryFileStatus = "Error creating inventory file at {$this->inventoryPath}: {$e->getMessage()}";
-            }
-
-            return;
-        }
-
-        // File exists - validate it
-        try {
-            $this->readInventory();
-            $this->inventoryFileStatus = "Reading inventory from {$this->inventoryPath}";
-        } catch (\Throwable $e) {
-            $this->inventoryFileStatus = "Error reading inventory file from {$this->inventoryPath}: {$e->getMessage()}";
-        }
-    }
 
     //
     // Dot Notation Helpers
@@ -212,26 +183,6 @@ class InventoryService
     }
 
     /**
-     * Check if path exists in nested array using dot notation path segments.
-     *
-     * @param array<string, mixed> $data
-     * @param array<int, string> $segments
-     */
-    private function hasByPath(array $data, array $segments): bool
-    {
-        $current = $data;
-
-        foreach ($segments as $segment) {
-            if (!is_array($current) || !array_key_exists($segment, $current)) {
-                return false;
-            }
-            $current = $current[$segment];
-        }
-
-        return true;
-    }
-
-    /**
      * Remove path from nested array using dot notation path segments.
      *
      * @param array<string, mixed> $data
@@ -266,48 +217,50 @@ class InventoryService
     // File Operations
 
     /**
-     * Read inventory YAML into a structured array.
-     *
-     * @return array<string, mixed>
+     * Get the resolved inventory path (custom or default).
      */
-    private function readInventory(): array
+    private function getInventoryPath(): string
     {
-        $path = $this->inventoryPath;
-
-        if (!$this->filesystem->exists($path)) {
-            return [];
-        }
-
-        $raw = $this->filesystem->readFile($path);
-        $parsed = Yaml::parse($raw);
-
-        /** @var array<string, mixed> $result */
-        $result = is_array($parsed) ? $parsed : [];
-        return $result;
+        return $this->inventoryPath ?? rtrim((string) getcwd(), '/') . '/inventory.yml';
     }
 
     /**
-     * Persist inventory data to YAML file.
+     * Read inventory YAML into internal array.
      *
-     * @param array<string, mixed> $inventory
+     * @throws \RuntimeException If file cannot be read or parsed
      */
-    private function writeInventory(array $inventory): void
+    private function readInventory(): void
     {
-        $path = $this->inventoryPath;
+        $path = $this->getInventoryPath();
 
-        if (!$this->filesystem->exists($this->inventoryDir)) {
-            try {
-                $this->filesystem->mkdir($this->inventoryDir, 0775);
-            } catch (\Throwable $e) {
-                throw new \RuntimeException("Unable to create inventory directory: {$this->inventoryDir}", 0, $e);
-            }
+        try {
+            $raw = $this->filesystem->readFile($path);
+            $parsed = Yaml::parse($raw);
+
+            /** @var array<string, mixed> $inventory */
+            $inventory = is_array($parsed) ? $parsed : [];
+            $this->inventory = $inventory;
+        } catch (\Throwable $e) {
+            throw new \RuntimeException("Error reading inventory file from {$path}: " . $e->getMessage());
+        }
+    }
+
+    /**
+     * Persist internal inventory to YAML file.
+     */
+    private function writeInventory(): void
+    {
+        if (null === $this->inventoryFileStatus) {
+            throw new \RuntimeException('Inventory not loaded. Call loadInventoryFile() first.');
         }
 
-        $yaml = Yaml::dump($inventory, 2, 4, Yaml::DUMP_EMPTY_ARRAY_AS_SEQUENCE);
+        $path = $this->getInventoryPath();
+
         try {
+            $yaml = Yaml::dump($this->inventory, 2, 4, Yaml::DUMP_EMPTY_ARRAY_AS_SEQUENCE);
             $this->filesystem->dumpFile($path, $yaml);
         } catch (\Throwable $e) {
-            throw new \RuntimeException("Failed to write inventory file at {$path}", 0, $e);
+            throw new \RuntimeException("Error writing inventory file at {$path}: " . $e->getMessage());
         }
     }
 }

--- a/app/SymfonyApp.php
+++ b/app/SymfonyApp.php
@@ -51,7 +51,9 @@ final class SymfonyApp extends SymfonyApplication
     {
         $this->io = new SymfonyStyle($input, $output);
 
-        $this->displayBanner();
+        if (!$output->isQuiet()) {
+            $this->displayBanner();
+        }
 
         return parent::doRun($input, $output);
     }
@@ -70,14 +72,14 @@ final class SymfonyApp extends SymfonyApplication
         // Simple, compact banner
         $banner = [
             '',
+            '<fg=cyan>╭───────</><fg=blue>─────────</><fg=bright-blue>─────────</><fg=magenta>─────────</><fg=gray>────────</>',
             ' <fg=cyan>┌┬┐┌─┐┌─┐┬  ┌─┐┬ ┬┌─┐┬─┐</>',
             ' <fg=cyan> ││├┤ ├─┘│  │ │└┬┘├┤ ├┬┘</>',
             ' <fg=blue>─┴┘└─┘┴  ┴─┘└─┘ ┴ └─┘┴└─PHP</> <fg=bright-blue>'.$version.'</>',
             '',
-            ' <fg=gray>The Server Provisioning & Deployment Tool for PHP</>',
-            '',
-            ' <fg=gray>Support this project on GitHub</> <fg=red>♥</>  <fg=magenta>https://github.com/bigpixelrocket/deployer-php</>',
-            '',
+            ' <fg=gray>The Server & Site Deployment Tool for PHP</>',
+            '<fg=cyan>╰───────</><fg=blue>─────────</><fg=bright-blue>─────────</><fg=magenta>─────────</><fg=gray>────────</>',
+            ''
         ];
 
         // Display the banner

--- a/tests/Integration/SymfonyAppTest.php
+++ b/tests/Integration/SymfonyAppTest.php
@@ -37,7 +37,7 @@ describe('SymfonyApp', function () {
     //
     // Banner display
 
-    it('displays complete banner with branding elements', function (array $expectedBannerElements) {
+    it('displays banner with branding elements', function (array $expectedBannerElements) {
         // ARRANGE
         $container = new Container();
         $app = $container->build(SymfonyApp::class);
@@ -62,13 +62,11 @@ describe('SymfonyApp', function () {
             }
         }
     })->with([
-        'complete banner' => [[
+        'banner' => [[
             '┌┬┐┌─┐┌─┐┬  ┌─┐┬ ┬┌─┐┬─┐', // ASCII art line 1
             ' ││├┤ ├─┘│  │ │└┬┘├┤ ├┬┘', // ASCII art line 2
             'VERSION_LINE', // Dynamic version line
-            'The Server Provisioning & Deployment Tool for PHP',
-            'Support this project on GitHub ♥',
-            'https://github.com/bigpixelrocket/deployer-php',
+            'The Server & Site Deployment Tool for PHP',
         ]]
     ]);
 

--- a/tests/Unit/Services/EnvServiceTest.php
+++ b/tests/Unit/Services/EnvServiceTest.php
@@ -19,36 +19,34 @@ describe('EnvService', function () {
     });
 
 
-    it('reports correct status for different .env file scenarios', function ($fileExists, $fileContent, $fileError, $expectedStatusPattern) {
+    it('reports correct status for different .env file scenarios', function ($fileExists, $fileContent, $expectsException, $expectedStatusPattern) {
         // ARRANGE
         $service = new EnvService(
-            mockFilesystem($fileExists, $fileContent, $fileError, false, false, '.env'),
+            mockFilesystem($fileExists, $fileContent, $expectsException, false, false, '.env'),
             new Dotenv()
         );
 
-        // ACT
-        $status = $service->getEnvFileStatus();
-
-        // ASSERT
-        expect($status)->toMatch($expectedStatusPattern);
+        // ACT & ASSERT
+        if ($expectsException) {
+            expect(fn () => $service->loadEnvFile())
+                ->toThrow(\RuntimeException::class, 'Error reading .env file from');
+        } else {
+            $service->loadEnvFile();
+            $status = $service->getEnvFileStatus();
+            expect($status)->toMatch($expectedStatusPattern);
+        }
     })->with([
         // No .env file exists
         [false, '', false, '/^No \.env file found at .+$/'],
 
-        // File exists and loads successfully with variables
-        [true, "API_KEY=test\nDB_HOST=localhost", false, '/^Reading 2 variables from .+\.env$/'],
-
-        // File exists with single variable
-        [true, 'SINGLE_KEY=value', false, '/^Reading 1 variable from .+\.env$/'],
-
         // File exists but is empty (no variables)
-        [true, '', false, '/^Reading 0 variables from .+\.env$/'],
+        [true, '', false, '/^No variables found in .+\.env$/'],
 
-        // File exists but has read error
-        [true, 'API_KEY=test', true, '/^Error reading \.env file from .+\.env$/'],
+        // File exists and loads successfully with variables
+        [true, "API_KEY=test\nDB_HOST=localhost", false, '/^Reading variables from .+\.env$/'],
 
-        // File exists with malformed content (triggers parse error)
-        [true, "VALID=test\nINVALID_LINE\nOTHER=value", false, '/^Error reading \.env file from .+\.env$/'],
+        // File exists but has read error (throws exception)
+        [true, 'API_KEY=test', true, null],
     ]);
 
     it('resolves environment variables from multiple sources with correct precedence', function ($env, $fileContent, $fileError, $keys, $expected) {
@@ -60,6 +58,7 @@ describe('EnvService', function () {
             mockFilesystem(!empty($fileContent), $fileContent, $fileError, false, false, '.env'),
             new Dotenv()
         );
+        $service->loadEnvFile();
 
         // ACT
         $result = $service->get($keys, false);
@@ -73,17 +72,16 @@ describe('EnvService', function () {
         }
     })->with([
         // Single key scenarios
-        [[], 'API_KEY=from_file', false, 'API_KEY', 'from_file'],                           // File only
-        [['API_KEY' => 'from_env'], 'API_KEY=from_file', false, 'API_KEY', 'from_file'],    // File wins over env
-        [['API_KEY' => ''], 'API_KEY=from_file', false, 'API_KEY', 'from_file'],           // Empty env ignored
-        [[], 'API_KEY=', false, 'API_KEY', null],                                          // Empty file ignored
-        [[], '', false, 'API_KEY', null],                                                  // File missing
-        [[], 'API_KEY=value', true, 'API_KEY', null],                                      // File read error
+        [[], 'API_KEY=from_file', false, 'API_KEY', 'from_file'],                         // File only
+        [['API_KEY' => 'from_env'], 'API_KEY=from_file', false, 'API_KEY', 'from_file'],  // File wins over env
+        [['API_KEY' => ''], 'API_KEY=from_file', false, 'API_KEY', 'from_file'],          // Empty env ignored
+        [[], 'API_KEY=', false, 'API_KEY', null],                                         // Empty file ignored
+        [[], '', false, 'API_KEY', null],                                                 // File missing
 
         // Multiple key scenarios (iterates in order, returns first found)
-        [['KEY1' => 'from_env'], 'KEY2=file_val', false, ['KEY1', 'KEY2'], 'from_env'],   // First key in env
-        [[], "KEY1=file_val\nKEY2=other", false, ['KEY1', 'KEY2'], 'file_val'],           // First key in file
-        [[], '', false, ['KEY1', 'KEY2'], null],                                          // No keys found
+        [['KEY1' => 'from_env'], 'KEY2=file_val', false, ['KEY1', 'KEY2'], 'from_env'],  // First key in env
+        [[], "KEY1=file_val\nKEY2=other", false, ['KEY1', 'KEY2'], 'file_val'],          // First key in file
+        [[], '', false, ['KEY1', 'KEY2'], null],                                         // No keys found
     ]);
 
     it('handles required vs optional parameters', function ($keys, $required, $expectsException, $expectedMessage) {
@@ -92,6 +90,7 @@ describe('EnvService', function () {
             mockFilesystem(false, '', false, false, false, '.env'),
             new Dotenv()
         );
+        $service->loadEnvFile();
 
         // ACT & ASSERT
         if ($expectsException) {
@@ -101,9 +100,9 @@ describe('EnvService', function () {
             expect($service->get($keys, $required))->toBeNull();
         }
     })->with([
-        ['MISSING_KEY', true, true, 'Missing environment variable: MISSING_KEY'],
-        [['KEY1', 'KEY2'], true, true, 'Missing environment variables: KEY1, KEY2'],
+        ['MISSING_KEY', true, true, 'Missing required environment variable: MISSING_KEY'],
+        [['KEY1', 'KEY2'], true, true, 'Missing required environment variables: KEY1, KEY2'],
         ['MISSING_KEY', false, false, null],
-        ['MISSING_KEY', true, true, 'Missing environment variable: MISSING_KEY'], // Default required=true
+        ['MISSING_KEY', true, true, 'Missing required environment variable: MISSING_KEY'],  // Default required=true
     ]);
 });

--- a/tests/Unit/Services/EnvServiceTest.php
+++ b/tests/Unit/Services/EnvServiceTest.php
@@ -103,6 +103,5 @@ describe('EnvService', function () {
         ['MISSING_KEY', true, true, 'Missing required environment variable: MISSING_KEY'],
         [['KEY1', 'KEY2'], true, true, 'Missing required environment variables: KEY1, KEY2'],
         ['MISSING_KEY', false, false, null],
-        ['MISSING_KEY', true, true, 'Missing required environment variable: MISSING_KEY'],  // Default required=true
     ]);
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * CLI commands now accept --env and --inventory options to use custom file paths.
  * Command runs now display environment and inventory statuses with clearer messages.
  * Banner is shown only in normal/verbose mode; quiet mode suppresses it.
* Documentation
  * Updated branding, header art, and badges in README.
* Tests
  * Expanded coverage for CLI options, quiet mode, and environment/inventory workflows.
* Chores
  * Added inventory.yml to .gitignore.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->